### PR TITLE
To fix Uncaught TypeError: jQuery.fn.button.noConflict is not a function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - travis_retry composer global require "fxp/composer-asset-plugin:^1.2.0"
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction
+  - travis_retry composer require --prefer-dist "yiisoft/yii2-bootstrap:~2.0.0"
 
 script:
   - phpunit

--- a/src/ElFinder.php
+++ b/src/ElFinder.php
@@ -64,7 +64,7 @@ class ElFinder extends Widget
         $view = $this->getView();
 
         if ($this->buttonNoConflict) {
-            $view->registerJs('jQuery.fn.btn = jQuery.fn.button.noConflict();');
+            ElFinderNoConflictAsset::register($view);
         }
 
         $bundle = ElFinderAsset::register($view);

--- a/src/ElFinderNoConflictAsset.php
+++ b/src/ElFinderNoConflictAsset.php
@@ -8,8 +8,13 @@ namespace alexantr\elfinder;
  */
 class ElFinderNoConflictAsset extends \yii\web\AssetBundle
 {
-    public $sourcePath = '@vendor/alexantr/yii2-elfinder/src/assets';
     public $js = ['no-conflict.js'];
 
     public $depends = ['yii\bootstrap\BootstrapPluginAsset', 'yii\jui\JuiAsset'];
+
+    public function init()
+    {
+        $this->sourcePath = __DIR__ . '/assets';
+        parent::init();
+    }
 }

--- a/src/ElFinderNoConflictAsset.php
+++ b/src/ElFinderNoConflictAsset.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace alexantr\elfinder;
+
+/**
+ * Asset to fix conflict between bootstrap-button.js and jQuery UI
+ * https://github.com/twbs/bootstrap/issues/6094
+ */
+class ElFinderNoConflictAsset extends \yii\web\AssetBundle
+{
+    public $sourcePath = __DIR__ . '/assets';
+    public $js = ['no-conflict.js'];
+
+    public $depends = ['yii\bootstrap\BootstrapPluginAsset', 'yii\jui\JuiAsset'];
+}

--- a/src/ElFinderNoConflictAsset.php
+++ b/src/ElFinderNoConflictAsset.php
@@ -8,7 +8,7 @@ namespace alexantr\elfinder;
  */
 class ElFinderNoConflictAsset extends \yii\web\AssetBundle
 {
-    public $sourcePath = __DIR__ . '/assets';
+    public $sourcePath = '@vendor/alexantr/yii2-elfinder/src/assets';
     public $js = ['no-conflict.js'];
 
     public $depends = ['yii\bootstrap\BootstrapPluginAsset', 'yii\jui\JuiAsset'];

--- a/src/assets/no-conflict.js
+++ b/src/assets/no-conflict.js
@@ -1,0 +1,1 @@
+jQuery.fn.btn = jQuery.fn.button.noConflict();

--- a/tests/ElFinderTest.php
+++ b/tests/ElFinderTest.php
@@ -155,6 +155,6 @@ class ElFinderTest extends TestCase
             'content' => $content,
         ]);
 
-        $this->assertContains('jQuery.fn.btn = jQuery.fn.button.noConflict();', $out);
+        $this->assertContains('no-conflict.js"></script>', $out);
     }
 }


### PR DESCRIPTION
If Yii2 application base on Pjax and after jumping by pages you jump in elfinder page with `no-conflict = true`  then you can catch error 

```
Uncaught TypeError: jQuery.fn.button.noConflict is not a function
```

This PR fixes this error by introducing ElFinderNoConflict Asset with dependents JUI and Bootsrap